### PR TITLE
Stop linking to defunct RCL project

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ jobs:
           branch: gh/bump-lts
           title: Bump Stackage LTS
           body: ${{ steps.bump.outputs.commit-message }}
-
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -58,18 +58,12 @@ To operate in a sub-directory:
 
 **NOTE**: Path options are relative to this.
 
-## Resolver Changelog
+## Package Diff
 
-The commit message will link to another project of ours, [Resolver
-Changelog][rcl]. For example,
+The commit message will link to a diff of packages changes between the
+resolvers. For example,
 
-[rcl]: https://github.com/freckle/rcl
-
-https://rcl.freckle.com?from=lts-16.29&to=lts-17.1
-
-This service displays the packages added, removed, or changed between the given
-two resolvers. And, where possible, the section of each dependency's Changelog
-relevant for the update.
+https://www.stackage.org/diff/lts-16.29/lts-17.1
 
 ---
 

--- a/action.yaml
+++ b/action.yaml
@@ -126,7 +126,7 @@ runs:
 
         See here for changed packages:
 
-        https://rcl.freckle.com/?from=$current&to=$latest
+        https://www.stackage.org/diff/$current/$latest
 
         EOM
         }


### PR DESCRIPTION
We took down this project, so the links generated here go nowhere. Might
as well link to the less useful stackage diff directly.
